### PR TITLE
feat - add classifier

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,5 @@
 # Smart Storage — IT Peripheral Recognition System
+
+from src.classifier_protocol import Classifier
+
+__all__ = ["Classifier"]

--- a/src/classifier_protocol.py
+++ b/src/classifier_protocol.py
@@ -1,0 +1,22 @@
+"""Classifier protocol — abstraction over the decision/classify step.
+
+Allows swapping the rule-based classifier for an ML model without
+touching Pipeline.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from src.models import Decision, DetectionResult
+
+
+@runtime_checkable
+class Classifier(Protocol):
+    """Structural protocol for any IT-peripheral classifier."""
+
+    def classify(
+        self,
+        detection: DetectionResult,
+        roi: np.ndarray | None = None,
+    ) -> Decision: ...

--- a/src/rule_based_classifier.py
+++ b/src/rule_based_classifier.py
@@ -1,0 +1,27 @@
+"""Rule-based classifier — wraps Pipeline.decide() behind the Classifier protocol."""
+
+import numpy as np
+
+from src.classifier_protocol import Classifier  # noqa: F401 — re-export hint
+from src.models import Decision, DetectionResult
+
+
+class RuleBasedClassifier:
+    """Classifier that delegates to Pipeline.decide() for rule-based decisions.
+
+    Satisfies the Classifier protocol, making it swappable for an ML model.
+    """
+
+    def __init__(self) -> None:
+        # Lazy import avoids a circular dependency with Pipeline → config chain
+        from src.pipeline import Pipeline  # noqa: PLC0415
+
+        self._pipeline = Pipeline()
+
+    def classify(
+        self,
+        detection: DetectionResult,
+        roi: np.ndarray | None = None,  # noqa: ARG002 — reserved for ML models
+    ) -> Decision:
+        """Return a Decision using the rule-based heuristics from Pipeline."""
+        return self._pipeline.decide(detection)

--- a/tests/test_classifier_protocol.py
+++ b/tests/test_classifier_protocol.py
@@ -1,0 +1,89 @@
+"""Tests verifying that RuleBasedClassifier satisfies the Classifier protocol."""
+
+import numpy as np
+import pytest
+
+from src.classifier_protocol import Classifier
+from src.models import ColorResult, Decision, DetectionResult
+from src.rule_based_classifier import RuleBasedClassifier
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def rule_based():
+    return RuleBasedClassifier()
+
+
+@pytest.fixture
+def sample_detection() -> DetectionResult:
+    """Minimal DetectionResult representing a small white object (charger-like)."""
+    color = ColorResult(name="white", confidence=0.85, method="hsv", rgb=(240, 240, 240))
+    return DetectionResult(
+        bbox=(280, 200, 40, 40),
+        color_hsv=color,
+        color_kmeans=ColorResult(name="white", confidence=0.80, method="kmeans", rgb=(235, 235, 235)),
+        primary_color="white",
+        size_category="small",
+        area_pixels=1600,
+        aspect_ratio=1.0,
+        area_ratio=0.005,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+def test_rule_based_classifier_is_instance_of_protocol(rule_based):
+    """RuleBasedClassifier must be a structural subtype of Classifier."""
+    assert isinstance(rule_based, Classifier)
+
+
+def test_classifier_protocol_has_classify_method():
+    """Classifier protocol requires a 'classify' method — verified structurally."""
+    assert hasattr(Classifier, "classify")
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests
+# ---------------------------------------------------------------------------
+
+def test_classify_returns_decision(rule_based, sample_detection):
+    result = rule_based.classify(sample_detection)
+    assert isinstance(result, Decision)
+
+
+def test_classify_with_roi_kwarg(rule_based, sample_detection):
+    """roi parameter must be accepted without error (reserved for ML models)."""
+    roi = np.zeros((40, 40, 3), dtype=np.uint8)
+    result = rule_based.classify(sample_detection, roi=roi)
+    assert isinstance(result, Decision)
+
+
+def test_classify_with_roi_none(rule_based, sample_detection):
+    result = rule_based.classify(sample_detection, roi=None)
+    assert isinstance(result, Decision)
+
+
+def test_classify_confidence_in_range(rule_based, sample_detection):
+    result = rule_based.classify(sample_detection)
+    assert 0.0 <= result.confidence <= 1.0
+
+
+def test_classify_returns_nonempty_category(rule_based, sample_detection):
+    result = rule_based.classify(sample_detection)
+    assert isinstance(result.category, str)
+    assert len(result.category) > 0
+
+
+# ---------------------------------------------------------------------------
+# Protocol is exportable from src package
+# ---------------------------------------------------------------------------
+
+def test_classifier_exported_from_src():
+    """Classifier must be importable from the src top-level package."""
+    from src import Classifier as C  # noqa: PLC0415
+    assert C is Classifier


### PR DESCRIPTION
Протокол Classifier даёт одну конкретную вещь: возможность поменять движок классификации, не трогая Pipeline.
Что это НЕ даёт прямо сейчас:

Никакой автоматической смены логики — Pipeline всё ещё вызывает self.decide() напрямую
Реального прироста точности — это только архитектурная заготовка
То есть сейчас это страховка на будущее: пока не нужна ML-модель — код работает как раньше, но когда она появится — менять нужно будет только один класс, а не переписывать весь пайплайн.