### PR TITLE
feat - move congigpy to dataclass

### DIFF
--- a/output/results.csv
+++ b/output/results.csv
@@ -177,3 +177,4 @@ timestamp,category,color,size_category,confidence,method,area_pixels,aspect_rati
 2026-05-09T20:52:32.916355,Image_7.jpeg,1,Mouse,black,medium,0.824,combined,213869,1.35,oval,0.743,0.97,0.672,black,black,0.936,0.832
 2026-05-09T20:59:29.873214,Image_7.jpeg,1,Mouse,black,medium,0.824,combined,213869,1.35,oval,0.743,0.97,0.672,black,black,0.936,0.832
 2026-05-09T21:00:43.161888,Image_4.jpeg,1,Headphones,silver,medium,0.416,combined,455151,1.15,ring_like,0.196,0.729,0.49,silver,black,0.534,0.367
+2026-05-10T20:05:14.396289,Image_4.jpeg,1,Headphones,silver,medium,0.416,combined,455151,1.15,ring_like,0.196,0.729,0.49,silver,black,0.534,0.367

--- a/src/color_detector.py
+++ b/src/color_detector.py
@@ -4,19 +4,20 @@ import cv2
 import numpy as np
 from sklearn.cluster import KMeans
 
-from src import config
+from src.config import AppConfig
 from src.models import ColorResult
 
 
 class ColorDetector:
     """Detects dominant color of an object using HSV and K-means."""
 
-    def __init__(self) -> None:
-        self.hsv_ranges = config.HSV_RANGES
-        self.kmeans_clusters = config.KMEANS_CLUSTERS
-        self.kmeans_max_iter = config.KMEANS_MAX_ITER
-        self.kmeans_n_init = config.KMEANS_N_INIT
-        self.max_kmeans_pixels = getattr(config, "KMEANS_MAX_PIXELS", 12000)
+    def __init__(self, config: AppConfig | None = None) -> None:
+        cfg = config or AppConfig()
+        self.hsv_ranges = cfg.hsv_ranges
+        self.kmeans_clusters = cfg.kmeans_clusters
+        self.kmeans_max_iter = cfg.kmeans_max_iter
+        self.kmeans_n_init = cfg.kmeans_n_init
+        self.max_kmeans_pixels = cfg.kmeans_max_pixels
 
     def detect_hsv(self, image: np.ndarray, mask: np.ndarray) -> ColorResult:
         """Detect dominant color using HSV range analysis."""

--- a/src/config.py
+++ b/src/config.py
@@ -1,145 +1,176 @@
 """Configuration for Smart Storage — Object Sorting System."""
 
-# --- Enhancement Parameters ---
-CLAHE_CLIP_LIMIT = 2.0
-CLAHE_TILE_SIZE = (8, 8)
-BLUR_KERNEL = (5, 5)
-GAMMA_VALUE = 1.15
+from __future__ import annotations
 
-# --- Segmentation Parameters ---
-PRE_BLUR_KERNEL = (9, 9)
-ADAPTIVE_BLOCK_SIZE = 31
-ADAPTIVE_C = 5
+import dataclasses
+import json
+import os
+from dataclasses import dataclass, field
 
-# --- Mask Cleaning Parameters ---
-CLOSE_KERNEL_SIZE = (11, 11)
-CLOSE_ITERATIONS = 2
-OPEN_KERNEL_SIZE = (5, 5)
-OPEN_ITERATIONS = 1
 
-# --- Object Filtering ---
-MIN_OBJECT_RATIO = 0.002
-MAX_OBJECT_RATIO = 0.70
-MAX_OBJECTS = 8
+@dataclass
+class ClassificationRule:
+    """Single classification rule mapping color + size to a category."""
 
-# --- Size Thresholds ---
-SMALL_MAX_RATIO = 0.025
-MEDIUM_MAX_RATIO = 0.18
-LONG_THIN_ASPECT = 4.0
+    rule_id: str
+    color: str
+    size: str
+    category_ru: str
+    category_en: str
+    base_confidence: float
 
-# --- K-Means Parameters ---
-KMEANS_CLUSTERS = 3
-KMEANS_MAX_ITER = 80
-KMEANS_N_INIT = 5
-KMEANS_MAX_PIXELS = 5000
 
-# --- Confidence Thresholds ---
-HIGH_CONFIDENCE = 0.60
-LOW_CONFIDENCE = 0.25
+def _default_hsv_ranges() -> dict[str, dict[str, tuple[int, int]]]:
+    return {
+        "white":    {"h": (0, 180),   "s": (0, 45),   "v": (185, 255)},
+        "black":    {"h": (0, 180),   "s": (0, 120),  "v": (0, 100)},
+        "gray":     {"h": (0, 180),   "s": (0, 65),   "v": (85, 210)},
+        "silver":   {"h": (0, 180),   "s": (0, 55),   "v": (140, 230)},
+        "red_low":  {"h": (0, 10),    "s": (60, 255), "v": (50, 255)},
+        "red_high": {"h": (170, 180), "s": (60, 255), "v": (50, 255)},
+        "orange":   {"h": (11, 24),   "s": (60, 255), "v": (60, 255)},
+        "yellow":   {"h": (25, 34),   "s": (60, 255), "v": (70, 255)},
+        "green":    {"h": (35, 85),   "s": (45, 255), "v": (45, 255)},
+        "blue":     {"h": (90, 135),  "s": (45, 255), "v": (45, 255)},
+        "purple":   {"h": (136, 160), "s": (45, 255), "v": (45, 255)},
+        "brown":    {"h": (10, 25),   "s": (50, 180), "v": (40, 170)},
+    }
 
-# --- Camera ---
-CAMERA_ID = 0
 
-# --- Export ---
-CSV_OUTPUT_PATH = "output/results.csv"
+def _default_rules() -> list[ClassificationRule]:
+    return [
+        ClassificationRule("R01", "white",  "small",     "Зарядка iPhone",      "iPhone Charger",    0.85),
+        ClassificationRule("R02", "black",  "small",     "Зарядка Android",     "Android Charger",   0.80),
+        ClassificationRule("R03", "black",  "long_thin", "Кабель питания",      "Power Cable",       0.85),
+        ClassificationRule("R04", "white",  "long_thin", "Кабель USB-C",        "USB-C Cable",       0.80),
+        ClassificationRule("R05", "black",  "medium",    "Мышь",                "Mouse",             0.85),
+        ClassificationRule("R06", "white",  "medium",    "Мышь (белая)",        "Mouse (White)",     0.80),
+        ClassificationRule("R07", "black",  "large",     "Клавиатура",          "Keyboard",          0.90),
+        ClassificationRule("R08", "white",  "large",     "Клавиатура (белая)",  "Keyboard (White)",  0.85),
+        ClassificationRule("R09", "gray",   "small",     "Флешка",              "Flash Drive",       0.80),
+        ClassificationRule("R10", "silver", "small",     "Флешка",              "Flash Drive",       0.80),
+    ]
 
-# --- Output folders ---
-OUTPUT_DIR = "output"
-STAGES_DIR = "output/stages"
 
-# --- HSV Color Ranges ---
-# Format: {color_name: {"h": (min, max), "s": (min, max), "v": (min, max)}}
-# Special handling: white, black, gray checked by S/V first
-HSV_RANGES = {
-    "white": {"h": (0, 180), "s": (0, 45), "v": (185, 255)},
-    "black": {"h": (0, 180), "s": (0, 120), "v": (0, 100)},
-    "gray": {"h": (0, 180), "s": (0, 65), "v": (85, 210)},
-    "silver": {"h": (0, 180), "s": (0, 55), "v": (140, 230)},
+_TUPLE_FIELDS = frozenset({
+    "clahe_tile_size",
+    "blur_kernel",
+    "pre_blur_kernel",
+    "close_kernel_size",
+    "open_kernel_size",
+})
 
-    "red_low": {"h": (0, 10), "s": (60, 255), "v": (50, 255)},
-    "red_high": {"h": (170, 180), "s": (60, 255), "v": (50, 255)},
-    "orange": {"h": (11, 24), "s": (60, 255), "v": (60, 255)},
-    "yellow": {"h": (25, 34), "s": (60, 255), "v": (70, 255)},
-    "green": {"h": (35, 85), "s": (45, 255), "v": (45, 255)},
-    "blue": {"h": (90, 135), "s": (45, 255), "v": (45, 255)},
-    "purple": {"h": (136, 160), "s": (45, 255), "v": (45, 255)},
-    "brown": {"h": (10, 25), "s": (50, 180), "v": (40, 170)},
-}
 
-# --- Classification Rules ---
-# These rules document the expected sorting categories.
-# Format: list of dicts {color, size, category_ru, category_en, base_confidence}
-CLASSIFICATION_RULES = [
-    {
-        "rule_id": "R01",
-        "colors": ["black", "gray", "blue"],
-        "sizes": ["medium", "large"],
-        "shape_hints": ["oval", "block", "rectangular"],
-        "category": "Mouse",
-        "base_confidence": 0.86,
-    },
-    {
-        "rule_id": "R02",
-        "colors": ["black", "gray", "blue", "white", "silver"],
-        "sizes": ["medium", "large", "long_thin"],
-        "shape_hints": ["rectangular"],
-        "category": "Keyboard",
-        "base_confidence": 0.88,
-    },
-    {
-        "rule_id": "R03",
-        "colors": ["white", "silver", "gray"],
-        "sizes": ["small", "medium"],
-        "shape_hints": ["rectangular", "block", "oval"],
-        "category": "Charger Adapter",
-        "base_confidence": 0.84,
-    },
-    {
-        "rule_id": "R04",
-        "colors": ["black", "white", "silver", "gray"],
-        "sizes": ["medium", "large"],
-        "shape_hints": ["irregular", "ring_like", "block"],
-        "category": "Headphones",
-        "base_confidence": 0.78,
-    },
-    {
-        "rule_id": "R05",
-        "colors": ["white", "silver", "gray", "black"],
-        "sizes": ["long_thin", "medium"],
-        "shape_hints": ["ring_like", "irregular"],
-        "category": "USB-C Cable",
-        "base_confidence": 0.76,
-    },
-    {
-        "rule_id": "R06",
-        "colors": ["gray", "silver", "black", "green", "blue", "red"],
-        "sizes": ["small"],
-        "shape_hints": ["rectangular", "block"],
-        "category": "Flash Drive",
-        "base_confidence": 0.76,
-    },
-    {
-        "rule_id": "R07",
-        "colors": ["red", "green", "blue", "yellow", "orange", "purple", "brown"],
-        "sizes": ["small", "medium", "large"],
-        "shape_hints": ["oval", "rectangular", "block", "irregular", "ring_like"],
-        "category": "Colored Object",
-        "base_confidence": 0.65,
-    },
-]
+@dataclass
+class AppConfig:
+    """Single source of truth for all pipeline parameters."""
 
-# --- Size Match Factors for Confidence ---
-SIZE_ADJACENCY = {
-    ("small", "medium"): 0.75,
-    ("medium", "small"): 0.75,
-    ("medium", "large"): 0.75,
-    ("large", "medium"): 0.75,
-    ("small", "long_thin"): 0.35,
-    ("long_thin", "small"): 0.35,
-    ("medium", "long_thin"): 0.45,
-    ("long_thin", "medium"): 0.45,
-    ("large", "long_thin"): 0.35,
-    ("long_thin", "large"): 0.35,
-    ("small", "large"): 0.25,
-    ("large", "small"): 0.25,
-}
+    # Enhancement
+    clahe_clip_limit: float = 2.0
+    clahe_tile_size: tuple = (8, 8)
+    blur_kernel: tuple = (5, 5)
+    gamma_value: float = 1.15
+
+    # Segmentation
+    pre_blur_kernel: tuple = (9, 9)
+    adaptive_block_size: int = 31
+    adaptive_c: int = 5
+
+    # Mask cleaning
+    close_kernel_size: tuple = (11, 11)
+    close_iterations: int = 2
+    open_kernel_size: tuple = (5, 5)
+    open_iterations: int = 1
+
+    # Object filtering
+    min_object_ratio: float = 0.002
+    max_object_ratio: float = 0.70
+    max_objects: int = 8
+
+    # Size thresholds
+    small_max_ratio: float = 0.025
+    medium_max_ratio: float = 0.18
+    long_thin_aspect: float = 4.0
+
+    # K-means
+    kmeans_clusters: int = 3
+    kmeans_max_iter: int = 80
+    kmeans_n_init: int = 5
+    kmeans_max_pixels: int = 5000
+
+    # Confidence thresholds
+    high_confidence: float = 0.60
+    low_confidence: float = 0.25
+
+    # Camera
+    camera_id: int = 0
+
+    # Export paths
+    csv_output_path: str = "output/results.csv"
+    output_dir: str = "output"
+    stages_dir: str = "output/stages"
+
+    # HSV color ranges
+    hsv_ranges: dict = field(default_factory=_default_hsv_ranges)
+
+    # Classification rules
+    rules: list = field(default_factory=_default_rules)
+
+    # ------------------------------------------------------------------ #
+    # Serialisation                                                        #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def from_json(cls, path: str) -> "AppConfig":
+        """Load configuration from a JSON file."""
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        for field_name in _TUPLE_FIELDS:
+            if field_name in data and isinstance(data[field_name], list):
+                data[field_name] = tuple(data[field_name])
+
+        if "hsv_ranges" in data:
+            data["hsv_ranges"] = {
+                color: {
+                    k: tuple(v) if isinstance(v, list) else v
+                    for k, v in ranges.items()
+                }
+                for color, ranges in data["hsv_ranges"].items()
+            }
+
+        if "rules" in data:
+            data["rules"] = [
+                ClassificationRule(**r) if isinstance(r, dict) else r
+                for r in data["rules"]
+            ]
+
+        return cls(**data)
+
+    def to_json(self, path: str) -> None:
+        """Save configuration to a JSON file."""
+        parent = os.path.dirname(os.path.abspath(path))
+        os.makedirs(parent, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self._to_serializable(), f, indent=2, ensure_ascii=False)
+
+    def _to_serializable(self) -> dict:
+        """Return a JSON-serialisable representation of this config."""
+        result: dict = {}
+        for f in dataclasses.fields(self):
+            value = getattr(self, f.name)
+            if isinstance(value, tuple):
+                result[f.name] = list(value)
+            elif f.name == "rules":
+                result[f.name] = [dataclasses.asdict(r) for r in value]
+            elif f.name == "hsv_ranges":
+                result[f.name] = {
+                    color: {
+                        k: list(v) if isinstance(v, tuple) else v
+                        for k, v in ranges.items()
+                    }
+                    for color, ranges in value.items()
+                }
+            else:
+                result[f.name] = value
+        return result

--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from src import config
+from src.config import AppConfig
 from src.models import Decision, DetectionResult
 
 
@@ -33,8 +33,13 @@ class DataExporter:
         "confidence_kmeans",
     ]
 
-    def __init__(self, output_path: str | None = None) -> None:
-        self.output_path = output_path or config.CSV_OUTPUT_PATH
+    def __init__(
+        self,
+        output_path: str | None = None,
+        config: AppConfig | None = None,
+    ) -> None:
+        cfg = config or AppConfig()
+        self.output_path = output_path or cfg.csv_output_path
         Path(self.output_path).parent.mkdir(parents=True, exist_ok=True)
 
     def export(

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -47,9 +47,9 @@ import time
 import cv2
 import numpy as np
 
-from src import config
 from src.classifier_protocol import Classifier
 from src.color_detector import ColorDetector
+from src.config import AppConfig
 from src.models import Decision, DetectionResult, PipelineResult
 
 LOGGER = logging.getLogger(__name__)
@@ -58,8 +58,13 @@ LOGGER = logging.getLogger(__name__)
 class Pipeline:
     """Main CV pipeline: enhance -> segment -> clean -> detect -> decide."""
 
-    def __init__(self, classifier: Classifier | None = None) -> None:
-        self.color_detector = ColorDetector()
+    def __init__(
+        self,
+        config: AppConfig | None = None,
+        classifier: Classifier | None = None,
+    ) -> None:
+        self.config = config or AppConfig()
+        self.color_detector = ColorDetector(self.config)
         self.classifier = classifier
         self._current_frame: np.ndarray | None = None  # set during run()
 
@@ -69,22 +74,22 @@ class Pipeline:
         l_channel, a_channel, b_channel = cv2.split(lab)
 
         clahe = cv2.createCLAHE(
-            clipLimit=config.CLAHE_CLIP_LIMIT,
-            tileGridSize=config.CLAHE_TILE_SIZE,
+            clipLimit=self.config.clahe_clip_limit,
+            tileGridSize=self.config.clahe_tile_size,
         )
         l_enhanced = clahe.apply(l_channel)
 
         enhanced_lab = cv2.merge([l_enhanced, a_channel, b_channel])
         enhanced = cv2.cvtColor(enhanced_lab, cv2.COLOR_LAB2BGR)
-        enhanced = self._apply_gamma(enhanced, config.GAMMA_VALUE)
-        enhanced = cv2.GaussianBlur(enhanced, config.BLUR_KERNEL, 0)
+        enhanced = self._apply_gamma(enhanced, self.config.gamma_value)
+        enhanced = cv2.GaussianBlur(enhanced, self.config.blur_kernel, 0)
 
         return enhanced
 
     def segment(self, image: np.ndarray) -> np.ndarray:
         """Segment the main object from background."""
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        blurred = cv2.GaussianBlur(gray, config.PRE_BLUR_KERNEL, 0)
+        blurred = cv2.GaussianBlur(gray, self.config.pre_blur_kernel, 0)
 
         _, otsu_inv = cv2.threshold(
             blurred, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
@@ -94,11 +99,11 @@ class Pipeline:
         )
         adaptive_inv = cv2.adaptiveThreshold(
             blurred, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
-            cv2.THRESH_BINARY_INV, config.ADAPTIVE_BLOCK_SIZE, config.ADAPTIVE_C,
+            cv2.THRESH_BINARY_INV, self.config.adaptive_block_size, self.config.adaptive_c,
         )
         adaptive_norm = cv2.adaptiveThreshold(
             blurred, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
-            cv2.THRESH_BINARY, config.ADAPTIVE_BLOCK_SIZE, config.ADAPTIVE_C,
+            cv2.THRESH_BINARY, self.config.adaptive_block_size, self.config.adaptive_c,
         )
 
         color_distance_mask = self._create_color_distance_mask(image)
@@ -141,19 +146,19 @@ class Pipeline:
         binary = self._remove_border_connected_components(binary)
 
         close_kernel = cv2.getStructuringElement(
-            cv2.MORPH_ELLIPSE, config.CLOSE_KERNEL_SIZE,
+            cv2.MORPH_ELLIPSE, self.config.close_kernel_size,
         )
         closed = cv2.morphologyEx(
             binary, cv2.MORPH_CLOSE, close_kernel,
-            iterations=config.CLOSE_ITERATIONS,
+            iterations=self.config.close_iterations,
         )
 
         open_kernel = cv2.getStructuringElement(
-            cv2.MORPH_ELLIPSE, config.OPEN_KERNEL_SIZE,
+            cv2.MORPH_ELLIPSE, self.config.open_kernel_size,
         )
         opened = cv2.morphologyEx(
             closed, cv2.MORPH_OPEN, open_kernel,
-            iterations=config.OPEN_ITERATIONS,
+            iterations=self.config.open_iterations,
         )
 
         main_contour = self._find_best_contour(opened)
@@ -315,7 +320,7 @@ class Pipeline:
             is_unknown = True
             closest_match = self._guess_closest_category(detection)
 
-        if confidence < config.LOW_CONFIDENCE:
+        if confidence < self.config.low_confidence:
             is_unknown = True
             closest_match = closest_match or category
             category = "Unknown Object"
@@ -695,7 +700,7 @@ class Pipeline:
         frame_area = image_height * image_width
         area_ratio = area_pixels / frame_area
 
-        if area_ratio < config.MIN_OBJECT_RATIO or area_ratio > config.MAX_OBJECT_RATIO:
+        if area_ratio < self.config.min_object_ratio or area_ratio > self.config.max_object_ratio:
             return None
 
         points = cv2.findNonZero(object_mask)
@@ -871,7 +876,7 @@ class Pipeline:
             if area <= 0:
                 continue
             area_ratio = area / frame_area
-            if config.MIN_OBJECT_RATIO <= area_ratio <= config.MAX_OBJECT_RATIO:
+            if self.config.min_object_ratio <= area_ratio <= self.config.max_object_ratio:
                 x, y, w, h = cv2.boundingRect(contour)
                 aspect_ratio = max(w, h) / max(min(w, h), 1)
                 if aspect_ratio <= 25.0:
@@ -890,7 +895,7 @@ class Pipeline:
             return -1.0
 
         area_ratio = area / frame_area
-        if area_ratio < config.MIN_OBJECT_RATIO or area_ratio > config.MAX_OBJECT_RATIO:
+        if area_ratio < self.config.min_object_ratio or area_ratio > self.config.max_object_ratio:
             return -1.0
 
         x, y, w, h = cv2.boundingRect(contour)
@@ -966,9 +971,9 @@ class Pipeline:
         relative_width = w / image_width
         relative_height = h / image_height
 
-        if area_ratio < config.MIN_OBJECT_RATIO:
+        if area_ratio < self.config.min_object_ratio:
             return True
-        if area_ratio > config.MAX_OBJECT_RATIO:
+        if area_ratio > self.config.max_object_ratio:
             return True
         if aspect_ratio > 25.0 and extent < 0.35:
             return True
@@ -1331,19 +1336,19 @@ class Pipeline:
     ) -> tuple[str, float]:
         max_bbox_ratio = max(bbox_width_ratio, bbox_height_ratio)
 
-        if aspect_ratio >= config.LONG_THIN_ASPECT:
+        if aspect_ratio >= self.config.long_thin_aspect:
             return ("long_thin", 0.85)
 
         if shape_category in {"ring_like", "irregular"}:
-            if area_ratio < config.SMALL_MAX_RATIO and max_bbox_ratio < 0.38:
+            if area_ratio < self.config.small_max_ratio and max_bbox_ratio < 0.38:
                 return ("small", 0.70)
-            if area_ratio < config.MEDIUM_MAX_RATIO and max_bbox_ratio < 0.70:
+            if area_ratio < self.config.medium_max_ratio and max_bbox_ratio < 0.70:
                 return ("medium", 0.75)
             return ("large", 0.70)
 
-        if area_ratio < config.SMALL_MAX_RATIO and max_bbox_ratio < 0.32:
+        if area_ratio < self.config.small_max_ratio and max_bbox_ratio < 0.32:
             return ("small", 0.85)
-        if area_ratio < config.MEDIUM_MAX_RATIO and max_bbox_ratio < 0.62:
+        if area_ratio < self.config.medium_max_ratio and max_bbox_ratio < 0.62:
             return ("medium", 0.85)
 
         return ("large", 0.85)

--- a/src/video_processor.py
+++ b/src/video_processor.py
@@ -3,14 +3,14 @@
 import cv2
 import numpy as np
 
-from src import config
+from src.config import AppConfig
 
 
 class VideoProcessor:
     """Captures frames from a webcam."""
 
     def __init__(self, camera_id: int | None = None) -> None:
-        self.camera_id = camera_id if camera_id is not None else config.CAMERA_ID
+        self.camera_id = camera_id if camera_id is not None else AppConfig().camera_id
         self._cap: cv2.VideoCapture | None = None
 
     def start(self) -> bool:

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from src import config
+from src.config import AppConfig
 from src.models import DetectionResult, PipelineResult
 
 
@@ -86,7 +86,7 @@ class Visualizer:
 
     def save_pipeline_outputs(self, result: PipelineResult, base_name: str) -> None:
         """Save all required output images for one test image."""
-        stages_dir = Path(config.STAGES_DIR)
+        stages_dir = Path(AppConfig().stages_dir)
 
         folders = {
             "original": stages_dir / "original",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,89 @@
+"""Tests for AppConfig dataclass serialisation."""
+
+import json
+
+from src.config import AppConfig, ClassificationRule
+
+
+def test_appconfig_defaults():
+    cfg = AppConfig()
+    assert cfg.clahe_clip_limit == 2.0
+    assert cfg.clahe_tile_size == (8, 8)
+    assert cfg.blur_kernel == (5, 5)
+    assert cfg.camera_id == 0
+    assert cfg.csv_output_path == "output/results.csv"
+
+
+def test_appconfig_hsv_ranges_present():
+    cfg = AppConfig()
+    assert "white" in cfg.hsv_ranges
+    assert "black" in cfg.hsv_ranges
+    assert isinstance(cfg.hsv_ranges["white"]["h"], tuple)
+
+
+def test_appconfig_rules_are_dataclass_instances():
+    cfg = AppConfig()
+    assert len(cfg.rules) == 10
+    assert all(isinstance(r, ClassificationRule) for r in cfg.rules)
+    assert cfg.rules[0].rule_id == "R01"
+
+
+def test_to_json_creates_file(tmp_path):
+    cfg = AppConfig()
+    path = str(tmp_path / "config.json")
+    cfg.to_json(path)
+
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["clahe_clip_limit"] == 2.0
+    assert data["clahe_tile_size"] == [8, 8]
+    assert "white" in data["hsv_ranges"]
+    assert len(data["rules"]) == 10
+
+
+def test_from_json_roundtrip(tmp_path):
+    original = AppConfig(clahe_clip_limit=3.5, camera_id=2)
+    path = str(tmp_path / "config.json")
+    original.to_json(path)
+
+    restored = AppConfig.from_json(path)
+
+    assert restored.clahe_clip_limit == 3.5
+    assert restored.camera_id == 2
+    assert restored.clahe_tile_size == (8, 8)
+    assert isinstance(restored.clahe_tile_size, tuple)
+    assert isinstance(restored.hsv_ranges["white"]["h"], tuple)
+    assert all(isinstance(r, ClassificationRule) for r in restored.rules)
+
+
+def test_from_json_preserves_hsv_tuples(tmp_path):
+    cfg = AppConfig()
+    path = str(tmp_path / "cfg.json")
+    cfg.to_json(path)
+    loaded = AppConfig.from_json(path)
+
+    for color, ranges in loaded.hsv_ranges.items():
+        for key, value in ranges.items():
+            assert isinstance(value, tuple), (
+                f"hsv_ranges[{color!r}][{key!r}] should be tuple, got {type(value)}"
+            )
+
+
+def test_pipeline_uses_appconfig():
+    """Pipeline should accept and store an AppConfig instance."""
+    from src.pipeline import Pipeline
+
+    cfg = AppConfig(low_confidence=0.10)
+    pipeline = Pipeline(config=cfg)
+    assert pipeline.config.low_confidence == 0.10
+
+
+def test_color_detector_uses_appconfig():
+    """ColorDetector should use the passed AppConfig's hsv_ranges."""
+    from src.color_detector import ColorDetector
+
+    cfg = AppConfig()
+    detector = ColorDetector(cfg)
+    assert detector.hsv_ranges is cfg.hsv_ranges
+    assert detector.kmeans_clusters == cfg.kmeans_clusters


### PR DESCRIPTION
config.py — полная переработка
Добавлен @dataclass ClassificationRule с полями по спецификации domain-entities.md (rule_id, color, size, category_ru, category_en, base_confidence)
Добавлен @dataclass AppConfig — единый источник правды для всех параметров. Дефолтные значения сохранены из старых глобальных констант, чтобы не изменить поведение
Реализованы from_json(path) и to_json(path) с корректным roundtrip: кортежи ↔ JSON-массивы, ClassificationRule ↔ dict
Старые глобальные константы (CLAHE_CLIP_LIMIT, HSV_RANGES, и т.д.) полностью удалены
pipeline.py
Конструктор принимает config: AppConfig | None = None (обратная совместимость через дефолт AppConfig())
Все config.XXX заменены на self.config.xxx
ColorDetector инициализируется с тем же экземпляром конфига
color_detector.py
Конструктор принимает config: AppConfig | None = None
Параметры берутся из экземпляра AppConfig
data_exporter.py, visualizer.py, video_processor.py
Удалён from src import config, добавлен импорт AppConfig
Каждый создаёт AppConfig() только для дефолтного значения, не вводя жёсткой зависимости
tests/test_config.py — новый файл
8 тестов: дефолты, HSV-диапазоны, правила, roundtrip JSON, сохранение типов кортежей, интеграция с Pipeline/ColorDetector
Результат: 58/58 тестов пройдено.