### PR TITLE
feat - add ml dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ cd smart-storage
 uv sync
 ```
 
+### Optional dependency groups
+
+Install only what you need — groups are independent of each other:
+
+| Group | What it installs | Command |
+|-------|-----------------|---------|
+| `ml-tabular` | LightGBM, joblib, matplotlib, albumentations | `uv sync --group ml-tabular` |
+| `ml-cnn` | PyTorch, torchvision, timm, albumentations, **Ultralytics YOLO** | `uv sync --group ml-cnn` |
+| `notebook` | Jupyter, matplotlib, seaborn | `uv sync --group notebook` |
+| `dev` | pytest, httpx | `uv sync --group dev` |
+
+Multiple groups can be combined:
+
+```bash
+uv sync --group ml-cnn --group notebook
+```
+
+> **Note:** `uv sync` without `--group` installs only core dependencies and does **not** pull in torch or any ML libraries.
+
 ## Usage
 
 ### Webcam mode (real-time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,27 @@ dev = [
     "httpx>=0.27,<1.0",
 ]
 
+ml-tabular = [
+    "lightgbm>=4.3",
+    "joblib>=1.3",
+    "matplotlib>=3.8",
+    "albumentations>=1.4",
+]
+
+ml-cnn = [
+    "torch>=2.2",
+    "torchvision>=0.17",
+    "timm>=0.9",
+    "albumentations>=1.4",
+    "ultralytics>=8.0",
+]
+
+notebook = [
+    "jupyter>=1.0",
+    "matplotlib>=3.8",
+    "seaborn>=0.13",
+]
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 


### PR DESCRIPTION
pyproject.toml — добавлены 3 новые dependency groups:

ml-tabular — LightGBM, joblib, matplotlib, albumentations
ml-cnn — torch, torchvision, timm, albumentations + ultralytics>=8.0 (YOLO для video-pipeline)
notebook — jupyter, matplotlib, seaborn
README.md — добавлена таблица с описанием групп и примерами команд установки.

Ключевые моменты:

uv sync без флагов — ставит только core-зависимости (OpenCV, NumPy, sklearn и т.д.), torch не скачивается
uv sync --group ml-tabular не тянет torch, группы полностью независимы
ultralytics добавлен в ml-cnn, так как YOLO — CNN-модель; он внутри уже требует torch, что логично в этой группе